### PR TITLE
いくつかのコマンドをMakefileに追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,13 @@
+install:
+	poetry env use 3.10
+	poetry install
+
+test-local:
+	if [ ! -d ".venv" ]; then\
+		make install;\
+	fi
+	poetry run pytest
+
 build:
 	docker build --platform linux/amd64 -t gcr.io/$(PROJECT_ID)/$(IMAGE):$(TAG) .
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ make run-local -f Makefile.dev
 make build run-local -f Makefile.dev
 ```
 
+- poetryで直接`.venv`を作成する場合
+``` shell
+make install
+```
+
+- ローカルで`.venv`環境を使ったpytestを実行する場合
+``` shell
+make test-local
+```
+
 #### 手動デプロイ
 - Makefile.prdなどを用意する。あとは以下のコマンドでdeployまで行う
 - デプロイ時に`FRONTEND_URL_hoge`を環境変数として渡す必要があるのでMakefile.prdで事前に定義する


### PR DESCRIPTION
### make install
#### 概要
- poetryを使って、ローカル環境に.venv仮想環境を直接作成するコマンド
#### 追加理由
- Dockerコンテナがあれば問題なくローカル開発が行えるが、後述のlocal-pytestを実行する際にいちいち別のコンテナを起動するのも煩わしいので、その前段階として.venv環境を作成できるようコマンド追加

### make test-local
#### 概要
- 先述の.venv環境を使ってpytestを行う
#### 追加理由
- ローカル環境でのpytestをDockerコンテナ内で行うのが煩わしいので直接.venv内で実行する
